### PR TITLE
Remove outdated info in the modifiers list

### DIFF
--- a/PartModifierScriptProperties.md
+++ b/PartModifierScriptProperties.md
@@ -1,15 +1,6 @@
 [Home](https://wnp78.github.io/Sr2Xml/)
 
 # PartModifier Properties
-These can all be used when referencing a part modifier by `id` in an InputController.
-They are displayed in the format of: `PartModifierId.Property`. In actual use, you could call the modifier anything you like. For instance, you could, on your fuel tank, set up:
-```xml
-<FuelTank id="MainFuelTank" />
-```
-then, in an `InputController`, use:
-```xml
-<InputController input="MainFuelTank.IsEmpty" />
-```
 Below is a table of all the different properties you can access, per modifier.
 
 |Name|Type|


### PR DESCRIPTION
The use of ids was really outdated and in the InputController page there's a more detailed and up-to-date explanation of how they work